### PR TITLE
Retarget dependent pull requests before closing a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ merge:
   # If true, bulldozer will delete branches after their pull requests merge.
   delete_after_merge: true
 
+  # If true, bulldozer will retarget other PRs based off the pull request's branch to the pull request's base.
+  # Only meaningful if delete_after_merge is true.
+  retarget_dependent_pull_requests: true
+
 # "update" defines how and when to update pull request branches. Unlike with
 # merges, if this section is missing, bulldozer will not update any pull requests.
 update:

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -36,7 +36,8 @@ type MergeConfig struct {
 	Whitelist Signals `yaml:"whitelist"`
 	Blacklist Signals `yaml:"blacklist"`
 
-	DeleteAfterMerge bool `yaml:"delete_after_merge"`
+	DeleteAfterMerge              bool `yaml:"delete_after_merge"`
+	RetargetDependentPullRequests bool `yaml:"retarget_dependent_pull_requests"`
 
 	Method  MergeMethod  `yaml:"method"`
 	Options MergeOptions `yaml:"options"`

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -141,12 +141,16 @@ func retargetDependentPullRequests(ctx context.Context, pullCtx pull.Context, me
 		return err
 	}
 
+	allErrs := []string{}
 	for _, pr := range prs {
 		if err := merger.ChangeBase(ctx, pullCtx, pr); err != nil {
-			return err
+			allErrs = append(allErrs, fmt.Sprintf("cannot retarget PR %d: %v", pullCtx.Number(), err))
 		}
 	}
 
+	if len(allErrs) > 0 {
+		return errors.New(strings.Join(allErrs, ", "))
+	}
 	return nil
 }
 

--- a/config/examples/standard.bulldozer.v1.yml
+++ b/config/examples/standard.bulldozer.v1.yml
@@ -12,6 +12,7 @@ merge:
     squash:
       body: summarize_commits
   delete_after_merge: true
+  retarget_dependent_pull_requests: true
 
 update:
   whitelist:

--- a/pull/context.go
+++ b/pull/context.go
@@ -16,6 +16,8 @@ package pull
 
 import (
 	"context"
+
+	"github.com/google/go-github/github"
 )
 
 // Context is the context for a pull request. It defines methods to get
@@ -78,6 +80,9 @@ type Context interface {
 
 	// Labels lists all labels on the pull request.
 	Labels(ctx context.Context) ([]string, error)
+
+	// PullRequestsForBranch returns the list open pull requests targeting the branch of this pull request
+	PullRequestsForBranch(ctx context.Context) ([]*github.PullRequest, error)
 
 	// IsTargeted returns true if the head branch of this pull request is the
 	// target branch of other open PRs on the repository.

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -282,10 +282,14 @@ func (ghc *GithubContext) Labels(ctx context.Context) ([]string, error) {
 	return labelNames, nil
 }
 
-func (ghc *GithubContext) IsTargeted(ctx context.Context) (bool, error) {
+func (ghc *GithubContext) PullRequestsForBranch(ctx context.Context) ([]*github.PullRequest, error) {
 	ref := fmt.Sprintf("refs/heads/%s", ghc.pr.GetHead().GetRef())
 
-	prs, err := ListOpenPullRequestsForRef(ctx, ghc.client, ghc.owner, ghc.repo, ref)
+	return ListOpenPullRequestsForRef(ctx, ghc.client, ghc.owner, ghc.repo, ref)
+}
+
+func (ghc *GithubContext) IsTargeted(ctx context.Context) (bool, error) {
+	prs, err := ghc.PullRequestsForBranch(ctx)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to determine targeted status")
 	}


### PR DESCRIPTION
Allows one to create a tree of interdependent PRs that will be properly merged
back into `master`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tectonic-network/bulldozer/1)
<!-- Reviewable:end -->
